### PR TITLE
Build script and custom XSLT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Master-Math304Notes.aux,Master-Math304Notes.log,Master-Math304Notes.out,Master-Math304Notes.synctex.gz
 HTML/index-CONFLICT-1.html
+output

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+for i in "$@"
+do
+case $i in
+    -f=*|--format=*) # Any string beginning with h or H: HTML
+	# Any string beginning with l or L: LaTeX
+	# (including calling pdflatex)
+	# Any other string: Error
+    FORMAT="${i#*=}"
+    shift # past argument=value
+    ;;
+    -p=*|--pubfile=*)
+    PUBFILE="${i#*=}"
+    shift # past argument=value
+    ;;
+    -x=*|--pretext=*)
+    PTX="${i#*=}"
+    shift # past argument=value
+    ;;
+    -o=*|--outdir=*)
+    OUTDIR="${i#*=}"
+    shift # past argument=value
+    ;;
+    *)
+          # unknown option
+    ;;
+esac
+done
+
+IBLMADIR=`pwd`
+
+
+case $FORMAT in
+    [hH]*)
+	cp ${IBLMLADIR}/xsl/ibl-modernalgebra-html.xsl ${PTX}/user
+	cd ${OUTDIR}
+	xsltproc -stringparam publisher ${PUBFILE} -xinclude ${PTX}/user/ibl-modernalgebra-html.xsl ${IBLMADIR}/ptx/index.ptx
+	;;
+    [lL]*)
+	cd ${OUTDIR}
+	xsltproc -o IBL-modernalgebra.tex -stringparam publisher ${PUBFILE} -xinclude ${PTX}/xsl/mathbook-latex.xsl ${IBLMADIR}/ptx/index.ptx
+	pdflatex IBL-modernalgebra
+	pdflatex IBL-modernalgebra
+	pdflatex IBL-modernalgebra
+	;;
+    *)
+	echo "Invalid format: ${FORMAT}"
+esac
+

--- a/xsl/ibl-modernalgebra-html.xsl
+++ b/xsl/ibl-modernalgebra-html.xsl
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!-- Customizations for HTML runs -->
+<!DOCTYPE xsl:stylesheet [
+    <!ENTITY % entities SYSTEM "../xsl/entities.ent">
+    %entities;
+]>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+
+<!-- Conveniences for classes of similar elements -->
+  
+<!-- Assumes current file is in mathbook/user, so it must be copied there -->
+<xsl:import href="../xsl/mathbook-html.xsl" />
+
+<!-- List Chapters and Sections in sidebar Table of Contents -->
+<xsl:param name="toc.level" select="'2'" />
+
+<!-- Examples and inline exercises are knowlized by default -->
+<!-- We disable this behavior  -->
+<xsl:param name="html.knowl.example" select="'no'" />
+<xsl:param name="html.knowl.exercise.inline" select="'no'" />
+
+<!-- Exercises may have hint, answer, and solution -->
+<xsl:param name="exercise.divisional.statement" select="'yes'" />
+<xsl:param name="exercise.divisional.hint" select="'yes'" />
+<xsl:param name="exercise.divisional.answer" select="'no'" />
+<xsl:param name="exercise.divisional.solution" select="'no'" />
+<xsl:param name="exercise.inline.statement" select="'yes'" />
+<xsl:param name="exercise.inline.hint" select="'yes'" />
+<xsl:param name="exercise.inline.answer" select="'no'" />
+<xsl:param name="exercise.inline.solution" select="'no'" />
+
+<xsl:param name="project.statement" select="'yes'" />
+<xsl:param name="project.hint" select="'yes'" />
+<xsl:param name="project.answer" select="'no'" />
+<xsl:param name="project.solution" select="'no'" />
+
+
+<!-- Specify the color scheme to use for HTML -->
+<xsl:param name="debug.colors" select="'blue_grey'" />
+
+<!-- Kill all proofs in output -->
+<xsl:template match="proof" />
+
+
+</xsl:stylesheet>


### PR DESCRIPTION
build.sh is now a build script that takes a variety of command line options:

-o=outputdirectory
-p=publisher XML file
-x=path to your mathbook directory
-f=output format (anything starting with h or H gets HTML. anything starting with l or L gets LaTeX including a call to pdflatex)

For instance, I called `./build.sh -f=p -o=output/html -p=ptx/pub.xml -x=/Users/justice/Documents/github/mathbook` to build the HTML.

The custom XSLT now suppresses all proofs and sets various stringparams that control exercise and project/activity/exploration/investigation answers/solutions.